### PR TITLE
Minor syntax fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for examples of reading and writing to blinds.
 ```javascript
 import MotionGateway from 'motionblinds'
 
-(async main() {
+(async function main () {
   // Initialize the MotionGateway class. Passing in the optional `key` parameter
   // enables write commands
   const gw = new MotionGateway('<YOUR_MOTION_KEY>')


### PR DESCRIPTION
Just found a minor syntax error in the README and wanted to say thank you for this great library. 

I have built https://github.com/pimatic/pimatic-motion-blinds on top of it.

I think there is a small error at handling the callbacks for sending and receiving. The `readAllDevices`-function mentioned in the README did not work for me. The network requests and responses did pass the wire, but the callback / promise did timeout. Just calling getDeviceList works well.